### PR TITLE
Use Centos rpm's for dependencies

### DIFF
--- a/scripts/installCentOsDepsUnattended.sh
+++ b/scripts/installCentOsDepsUnattended.sh
@@ -47,23 +47,7 @@ install_apt_deps(){
   # the packages that we need
   sudo yum -y install epel-release
   # now that yum knows about epel it can install the rest of the packages
-  sudo yum -y install patch git make gcc openssl-devel cmake pkgconfig nodejs glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel npm yasm java-1.7.0-openjdk
-}
-
-install_openssl(){
-  if [ -d $LIB_DIR ]; then
-    cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -xf openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
-    ./config --prefix=$PREFIX_DIR -fPIC
-    make -s V=0
-    make install_sw
-    cd $CURRENT_DIR
-  else
-    mkdir -p $LIB_DIR
-    install_openssl
-  fi
+  sudo yum -y install patch git make gcc libvpx-devel opus-devel openssl-devel cmake pkgconfig nodejs glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel npm yasm java-1.7.0-openjdk
 }
 
 install_libnice(){
@@ -81,30 +65,6 @@ install_libnice(){
     mkdir -p $LIB_DIR
     install_libnice
   fi
-}
-
-install_opus(){
-  [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
-  cd $LIB_DIR
-  curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
-  tar -xf opus-1.1.tar.gz
-  cd opus-1.1
-  ./configure --prefix=$PREFIX_DIR
-  make -s V=0
-  make install
-  cd $CURRENT_DIR
-}
-
-install_vpx(){
-  [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
-  cd $LIB_DIR
-  curl -O https://webm.googlecode.com/files/libvpx-v1.0.0.tar.bz2
-  tar -xf libvpx-v1.0.0.tar.bz2
-  cd libvpx-v1.0.0
-  ./configure --prefix=$PREFIX_DIR --enable-vp8 --enable-shared --enable-pic
-  make -s V=0
-  make install
-  cd $CURRENT_DIR
 }
 
 install_mediadeps(){
@@ -154,7 +114,6 @@ cleanup(){
     cd $LIB_DIR
     rm -r libnice*
     rm -r libav*
-    rm -r openssl*
     cd $CURRENT_DIR
   fi
 }
@@ -167,14 +126,9 @@ install_apt_deps
 
 check_proxy
 
-install_openssl
-
 install_libnice
 
 install_libsrtp
-
-install_opus
-install_vpx
 
 if [ "$ENABLE_GPL" = "true" ]; then
   install_mediadeps


### PR DESCRIPTION
This commit uses centos/epel rpm's for openssl, opus, and libvpx.
libsrtp has a patch so we'll need to build our own rpm, and libav
doesn't seem to be packaged for centos so I'll need to find an rpmspec
and build our own rpm.
