### PR TITLE
Copy video after closing

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -488,14 +488,6 @@ var listen = function () {
             log.info("erizoController.js: Stopping recording  " + recordingId + " url " + url);
             socket.room.controller.removeExternalOutput(url, callback);
 
-	    var sessionToken = recordingId;
-            log.info("erizoController.js: affdex.saveVideo " + recordingId);
-
-            affdex.saveVideo(sessionToken, url, function(err, data) {
-		log.info('saveVideo callback');
-		log.info(data);
-	    });
-
         });
 
         //Gets 'unpublish' messages on the socket in order to remove a stream from the room.
@@ -586,11 +578,24 @@ var listen = function () {
                         if( socket.room.streams[id]) {
                             if (socket.room.streams[id].hasAudio() || socket.room.streams[id].hasVideo() || socket.room.streams[id].hasScreen()) {
                                 if (!socket.room.p2p) {
-                                    socket.room.controller.removePublisher(id);
-                                    if (GLOBAL.config.erizoController.report.session_events) {
-                                        var timeStamp = new Date();
-                                        amqper.broadcast('event', {room: socket.room.id, user: socket.id, type: 'unpublish', stream: id, timestamp: timeStamp.getTime()});
-                                    }
+
+                                    var recordingId = socket.room.id;
+                                    var url = '/tmp/' + recordingId + '.mkv';
+
+                                    log.info("erizoController.js: affdex.saveVideo " + url);
+
+                                    affdex.saveVideo(recordingId, url, function(err, data) {
+
+                                        log.info('saveVideo callback');
+                                        log.info(data);
+
+                                        socket.room.controller.removePublisher(id);
+                                        if (GLOBAL.config.erizoController.report.session_events) {
+                                            var timeStamp = new Date();
+                                            amqper.broadcast('event', {room: socket.room.id, user: socket.id, type: 'unpublish', stream: id, timestamp: timeStamp.getTime()});
+                                        }
+                                    });
+
                                 }
                             }
 

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -142,6 +142,20 @@ var sendMsgToRoom = function (room, type, arg) {
     }
 };
 
+/*
+ * DRY support for getting the recording url from the recordingId
+ */
+var buildRecordingUrl = function (recordingId) {
+    var url, fileExtension = '.mkv';
+
+    if (GLOBAL.config.erizoController.recording_path) {
+        url = GLOBAL.config.erizoController.recording_path + recordingId + fileExtension;
+    } else {
+        url = '/tmp/' + recordingId + fileExtension;
+    }
+    return url;
+}
+
 var privateRegexp;
 var publicIP;
 
@@ -320,11 +334,7 @@ var listen = function () {
                 var url = sdp;
                 if (options.state === 'recording') {
                     var recordingId = sdp;
-                    if (GLOBAL.config.erizoController.recording_path) {
-                        url = GLOBAL.config.erizoController.recording_path + recordingId + '.mkv';
-                    } else {
-                        url = '/tmp/' + recordingId + '.mkv';
-                    }
+                    url = buildRecordingUrl(recordingId);
                 }
                 socket.room.controller.addExternalInput(id, url, function (result) {
                     if (result === 'success') {
@@ -447,13 +457,7 @@ var listen = function () {
         socket.on('startRecorder', function (options, callback) {
             var streamId = options.to;
             var recordingId = socket.room.id;
-            var url;
-
-            if (GLOBAL.config.erizoController.recording_path) {
-                url = GLOBAL.config.erizoController.recording_path + recordingId + '.mkv';
-            } else {
-                url = '/tmp/' + recordingId + '.mkv';
-            }
+            var url = buildRecordingUrl(recordingId);
 
             log.info("erizoController.js: Starting recorder streamID " + streamId + "url ", url);
 
@@ -477,13 +481,7 @@ var listen = function () {
         socket.on('stopRecorder', function (options, callback) {
             var recordingId = socket.room.id;
 
-            var url;
-
-            if (GLOBAL.config.erizoController.recording_path) {
-                url = GLOBAL.config.erizoController.recording_path + recordingId + '.mkv';
-            } else {
-                url = '/tmp/' + recordingId + '.mkv';
-            }
+            var url = buildRecordingUrl(recordingId);
 
             log.info("erizoController.js: Stopping recording  " + recordingId + " url " + url);
             socket.room.controller.removeExternalOutput(url, callback);
@@ -580,7 +578,7 @@ var listen = function () {
                                 if (!socket.room.p2p) {
 
                                     var recordingId = socket.room.id;
-                                    var url = '/tmp/' + recordingId + '.mkv';
+                                    var url = buildRecordingUrl(recordingId);
 
                                     log.info("erizoController.js: affdex.saveVideo " + url);
 


### PR DESCRIPTION
Mosified when we copy the files to S3 to be in the part of the code where the client leaves the "room" instead of when we stop recording.  This should address an issue where the file isn't closed out, which causes short videos.

I also simplified the code where we construct the recording urls to be in one place.
