### PR TITLE
fix sdp offer bundle parsing when streaming video-only or audio-only

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -648,8 +648,9 @@ namespace erizo {
           ELOG_DEBUG("BUNDLE sdp");
           isBundle = true;
         }
-        if (parts.size()>=4){
-          for (unsigned int tagno=2; tagno<parts.size(); tagno++){
+        // number of parts will vary depending on whether audio and video are present in the bundle
+        if (parts.size() >= 3) {
+          for (unsigned int tagno=2; tagno<parts.size(); tagno++) {
             ELOG_DEBUG("Adding %s to bundle vector", parts[tagno].c_str());
             BundleTag theTag(parts[tagno], OTHER);
             bundleTags.push_back(theTag);


### PR DESCRIPTION
The fix is to simply change the 4 to a 3 so that the conditional code to add the BundleTag objects to the bundleTags vector.  Credit to Jeremy Noring on the lynckia google group for finding this fix.

In the case of video-only `a=group:BUNDLE video` or audio-only `a=group:BUNDLE audio`, the number of parts is only 3.  Without the bundle tags, the remote description had an invalid bundle definition `a=group:BUNDLE`.  Most of the time with WebRTC the bundle definition will be `a=group:BUNDLE audio video` for audio and video streaming.

This fixes video-only and audio-only streaming in Chrome 47.
