### PR TITLE
Install node from tar

### DIFF
--- a/scripts/installCentOsDepsUnattended.sh
+++ b/scripts/installCentOsDepsUnattended.sh
@@ -47,7 +47,16 @@ install_apt_deps(){
   # the packages that we need
   sudo yum -y install epel-release
   # now that yum knows about epel it can install the rest of the packages
-  sudo yum -y install patch git make gcc bzip2-devel x264-devel libav-devel libnice-devel libsrtp-devel libvpx-devel opus-devel openssl-devel cmake pkgconfig nodejs glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel npm yasm java-1.7.0-openjdk
+  sudo yum -y install patch git make gcc bzip2-devel x264-devel libav-devel libnice-devel libsrtp-devel libvpx-devel opus-devel openssl-devel cmake pkgconfig glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel yasm java-1.7.0-openjdk
+}
+
+install_node(){
+    # we used to use epel packages but they upgraded to a version of
+    # nodejs that's incompatible with licode so now we get it from the
+    # upstream source
+    wget http://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x64.tar.xz
+    sudo tar --strip-components 1 -xJf node-v* -C /usr/local
+    sudo npm install -g node-gyp
 }
 
 parse_arguments $*
@@ -55,5 +64,6 @@ parse_arguments $*
 mkdir -p $PREFIX_DIR
 
 install_apt_deps
+install_node
 
 check_proxy

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -40,7 +40,7 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl --silent --output - http://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz | tar xzf -
+    curl --silent --output - https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz | tar xzf -
     cd libnice-0.1.4
     ./configure --prefix=$PREFIX_DIR
     make -s V=0

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
@@ -25,7 +25,7 @@ parse_arguments(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl --output - http://www.openssl.org/source/openssl-1.0.1g.tar.gz | tar xzf -
+    curl --silent --output - https://www.openssl.org/source/openssl-1.0.1g.tar.gz | tar xzf -
     cd openssl-1.0.1g
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0
@@ -40,8 +40,7 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
-    tar -zxvf libnice-0.1.4.tar.gz > /dev/null 2> /dev/null
+    curl --silent --output - http://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz | tar xzf -
     cd libnice-0.1.4
     ./configure --prefix=$PREFIX_DIR
     make -s V=0
@@ -56,8 +55,7 @@ install_libnice(){
 install_mediadeps(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-11.1.tar.gz
-    tar -zxvf libav-11.1.tar.gz > /dev/null 2> /dev/null
+    curl --silent --output - https://www.libav.org/releases/libav-11.1.tar.gz | tar xzf -
     cd libav-11.1
     ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264
     make -s V=0
@@ -73,8 +71,7 @@ install_mediadeps(){
 install_mediadeps_nogpl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-11.1.tar.gz
-    tar -zxvf libav-11.1.tar.gz > /dev/null 2> /dev/null
+    curl --silent --output - https://www.libav.org/releases/libav-11.1.tar.gz | tar xzf -
     cd libav-11.1
     ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx
     make -s V=0
@@ -87,8 +84,7 @@ install_mediadeps_nogpl(){
 }
 
 install_libsrtp(){
-  curl -O -L https://github.com/cisco/libsrtp/archive/v1.5.2.tar.gz
-  tar -zxvf v1.5.2.tar.gz > /dev/null 2> /dev/null
+  curl --silent --output - -L https://github.com/cisco/libsrtp/archive/v1.5.2.tar.gz | tar xzf -
   cd libsrtp-1.5.2
   CFLAGS="-fPIC" ./configure --prefix=$PREFIX_DIR
   make -s V=0

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -25,8 +25,7 @@ parse_arguments(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -zxvf openssl-1.0.1g.tar.gz > /dev/null 2> /dev/null
+    curl --output - http://www.openssl.org/source/openssl-1.0.1g.tar.gz | tar xzf -
     cd openssl-1.0.1g
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0


### PR DESCRIPTION
This change installs nodejs from the upstream tarballs, not from epel rpm's.  Epel is more like Fedora than Centos in that it changes major versions whenever.

This also makes some changes to fix the Travis build.  Some of the sites that we download build-deps from switched to https which confused curl.
