### PR TITLE
Pin the request and log4js modules at versions known to work with node v0.10.x

### DIFF
--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -2,7 +2,7 @@
 
 echo [erizo_controller] Installing node_modules for erizo_controller
 
-npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt serve-static finalhandler affdex-licode
+npm install --loglevel error amqp socket.io@0.9.16 log4js@0.6.29 node-getopt serve-static finalhandler affdex-licode
 
 echo [erizo_controller] Done, node_modules installed
 

--- a/scripts/installCentOsDepsUnattended.sh
+++ b/scripts/installCentOsDepsUnattended.sh
@@ -56,7 +56,7 @@ install_node(){
     # upstream source
     wget http://nodejs.org/dist/v0.10.36/node-v0.10.36-linux-x64.tar.gz
     sudo tar --strip-components 1 -xzf node-v* -C /usr/local
-    sudo npm install -g node-gyp@0.10.6
+    sudo npm install -g node-gyp@0.10.6 request@2.25.0
 }
 
 parse_arguments $*


### PR DESCRIPTION
This change allows us to build and run licode.  Some of the newer module versions
are requiring node v4+ and that isn't supported on the version of licode that we have.

- request was pinned at v2.25
- log4js was pinned at v0.6.29