### PR TITLE
Modify CentOSDepsUnattended script to install a version of openssl th…

### DIFF
--- a/scripts/installCentOsDepsUnattended.sh
+++ b/scripts/installCentOsDepsUnattended.sh
@@ -47,7 +47,7 @@ install_apt_deps(){
   # the packages that we need
   sudo yum -y install epel-release
   # now that yum knows about epel it can install the rest of the packages
-  sudo yum -y install patch git make gcc bzip2-devel x264-devel libav-devel libnice-devel libsrtp-devel libvpx-devel opus-devel openssl-devel cmake pkgconfig glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel yasm java-1.7.0-openjdk
+  sudo yum -y install patch git make gcc bzip2-devel x264-devel libav-devel libnice-devel libsrtp-devel libvpx-devel opus-devel cmake pkgconfig glib2-devel boost-devel boost-regex boost-thread boost-system log4cxx-devel rabbitmq-server curl boost-test tar xz libffi-devel yasm java-1.7.0-openjdk
 }
 
 install_node(){
@@ -59,11 +59,46 @@ install_node(){
     sudo npm install -g node-gyp@0.10.6 request@2.25.0
 }
 
+download_openssl() {
+  OPENSSL_VERSION=$1
+  OPENSSL_MAJOR="${OPENSSL_VERSION%?}"
+  echo "Downloading OpenSSL from https://www.openssl.org/source/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
+  curl -OL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+  tar -zxvf openssl-$OPENSSL_VERSION.tar.gz || DOWNLOAD_SUCCESS=$?
+  if [ "$DOWNLOAD_SUCCESS" -eq 1 ]
+  then
+    echo "Downloading OpenSSL from https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
+    curl -OL https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
+    tar -zxvf openssl-$OPENSSL_VERSION.tar.gz
+  fi
+}
+
+install_openssl(){
+  if [ -d $LIB_DIR ]; then
+    cd $LIB_DIR
+    OPENSSL_VERSION=`node -pe process.versions.openssl`
+    if [ ! -f ./openssl-$OPENSSL_VERSION.tar.gz ]; then
+      download_openssl $OPENSSL_VERSION
+      cd openssl-$OPENSSL_VERSION
+      ./config --prefix=$PREFIX_DIR --openssldir=$PREFIX_DIR -fPIC
+      make $FAST_MAKE -s V=0
+      make install_sw
+    else
+      echo "openssl already installed"
+    fi
+    cd $CURRENT_DIR
+  else
+    mkdir -p $LIB_DIR
+    install_openssl
+  fi
+}
+
 parse_arguments $*
 
 mkdir -p $PREFIX_DIR
 
 install_apt_deps
 install_node
+install_openssl
 
 check_proxy


### PR DESCRIPTION
…at is supported by node

This change fixes a runtime issue with the licode DTLS/SSL handshake.  It was previously having
an error during the handshake process:

ERROR: dtls.DtlsSocket - SSL error 1

It turns out that using the system openssl isn't recommended.  The script has been modified to
query node js via `node -pe process.versions.openssl` to determine which version of openssl to use.

Note that the system openssl is a newer version than the one node is expecting:

$ openssl version
OpenSSL 1.0.2k-fips  26 Jan 2017

$ node -pe process.versions.openssl
1.0.1l